### PR TITLE
管理者機能を修正

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,3 +1,4 @@
 class Admin::AdminController < ApplicationController
+  layout 'layouts/admin/admin'
   before_action :authenticate_admin!
 end

--- a/app/controllers/admin/animes_controller.rb
+++ b/app/controllers/admin/animes_controller.rb
@@ -7,15 +7,24 @@ class Admin::AnimesController < Admin::AdminController
   end
 
   def create
-    Anime.create!(anime_params)
-    redirect_to admin_animes_path
+    @anime = Anime.new(anime_params)
+
+    if @anime.save
+      redirect_to admin_animes_path
+    else
+      @animes = Anime.order(id: :asc)
+      render :index, status: :unprocessable_entity
+    end
   end
 
   def edit; end
 
   def update
-    @anime.update!(anime_params)
-    redirect_to admin_animes_path
+    if @anime.update(anime_params)
+      redirect_to admin_animes_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/controllers/admin/animes_controller.rb
+++ b/app/controllers/admin/animes_controller.rb
@@ -2,7 +2,7 @@ class Admin::AnimesController < Admin::AdminController
   before_action :set_anime, only: %i[edit update destroy]
 
   def index
-    @animes = Anime.order(id: :asc)
+    @animes = Anime.published.order(id: :asc)
     @anime = Anime.new
   end
 
@@ -28,8 +28,8 @@ class Admin::AnimesController < Admin::AdminController
   end
 
   def destroy
-    @anime.destroy!
-    redirect_to admin_animes_path
+    @anime.update!(status: 'deleted')
+    redirect_to admin_animes_path, status: :see_other, notice: t('notice.destroy')
   end
 
   private

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,6 +1,6 @@
 class Admin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  # :registerable, :recoverable
+  devise :database_authenticatable, :rememberable, :validatable
 end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -4,6 +4,8 @@ class Anime < ApplicationRecord
 
   validates :title, presence: true, uniqueness: true
 
+  enum status: { published: 0, deleted: 1 }
+
   class << self
     def having_quiz_collection
       joins(:quizzes)

--- a/app/views/admin/animes/edit.html.erb
+++ b/app/views/admin/animes/edit.html.erb
@@ -1,8 +1,10 @@
 <div class="container mt-3">
   <h1 class="my-4">編集</h1>
-  <%= simple_form_for [:admin, @anime] do |f| %>
-    <%= f.input :title %>
-    <%= f.button :submit, class: "btn btn-primary" %>
-  <% end %>
+  <div class="mb-4">
+    <%= simple_form_for [:admin, @anime] do |f| %>
+      <%= f.input :title %>
+      <%= f.button :submit, class: "btn btn-primary" %>
+    <% end %>
+  </div>
   <%= link_to "戻る", admin_animes_path %>
 </div>

--- a/app/views/admin/animes/index.html.erb
+++ b/app/views/admin/animes/index.html.erb
@@ -1,5 +1,6 @@
 <div class="container mt-3">
   <h1 class="my-4"><%= Anime.model_name.human %>作品</h1>
+  <p class="mb-3"><%= link_to "トップに戻る", admin_root_path %></p>
   <div class="card">
     <div class="card-body">
       <%= simple_form_for [:admin, @anime] do |f| %>

--- a/app/views/layouts/admin/_header.html.erb
+++ b/app/views/layouts/admin/_header.html.erb
@@ -8,11 +8,6 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
           <% if admin_signed_in? %>
-            <%= link_to "アカウント編集", edit_admin_registration_path, class: 'nav-link active' %>
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <% if admin_signed_in? %>
             <%= link_to "管理者ログアウト", destroy_admin_session_path, class: 'nav-link active me-2', data: { turbo_method: :delete, turbo_confirm: 'ログアウトしますか？' } %>
           <% end %>
         </li>

--- a/app/views/layouts/admin/admin.html.erb
+++ b/app/views/layouts/admin/admin.html.erb
@@ -10,7 +10,7 @@
   </head>
   <body>
     <header class="mb-3">
-      <%= render "layouts/header" %>
+      <%= render "layouts/admin/header" %>
     </header>
     <%= render "partials/flash" %>
     <%= yield %>

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -3,17 +3,17 @@
   <h1 class="my-4"><%= Quiz.model_name.human %><%= target %></h1>
   <div class="mb-4">
     <%= simple_form_for @quiz do |f| %>
-      <p><%= f.input :anime, as: :select, collection: Anime.pluck(:title, :id), selected: @quiz.anime_id, prompt: '選択してください', label: "#{Anime.model_name.human}作品" %></p>
+      <p><%= f.input :anime, as: :select, collection: Anime.published.pluck(:title, :id), selected: @quiz.anime_id, prompt: '選択してください', label: "#{Anime.model_name.human}作品" %></p>
       <p><%= f.input :question, label: "#{Quiz.human_attribute_name(:question)}", input_html: { rows: 6 } %></p>
       <p><%= f.input :published_at, as: :hidden %></p>
       <div class="my-4">
         <p>選択肢<span class="small ms-3" style="color: #777;">正解の選択肢どれか1つにチェック☑︎</span></p>
         <%= f.simple_fields_for :choices do |cf| %>
-          <div class="row">
-            <div class="col-1">
+          <div class="d-flex align-items-center">
+            <div class="me-3">
               <%= cf.input :is_correct, label: "#{Choice.human_attribute_name(:is_correct)}", as: :boolean, checked_value: 'true', unchecked_value: 'false', label: false, error: '' %>
             </div>
-            <div class="col-11">
+            <div class="flex-grow-1">
               <%= cf.input :body, label: false %>
             </div>
           </div>

--- a/config/locales/models/anime.ja.yml
+++ b/config/locales/models/anime.ja.yml
@@ -5,3 +5,4 @@ ja:
     attributes:
       anime:
         title: タイトル
+        status: ステータス

--- a/db/fixtures/admin.rb
+++ b/db/fixtures/admin.rb
@@ -1,0 +1,5 @@
+Admin.seed do |s|
+  s.id = 1
+  s.email = 'admin@example.com'
+  s.password = 'password'
+end

--- a/db/migrate/20220905153516_remove_recoverable_from_admins.rb
+++ b/db/migrate/20220905153516_remove_recoverable_from_admins.rb
@@ -1,0 +1,7 @@
+class RemoveRecoverableFromAdmins < ActiveRecord::Migration[7.0]
+  def change
+    remove_index  :admins, :reset_password_token, unique: true
+    remove_column :admins, :reset_password_token, :string
+    remove_column :admins, :reset_password_sent_at, :datetime
+  end
+end

--- a/db/migrate/20220909065650_add_status_to_animes.rb
+++ b/db/migrate/20220909065650_add_status_to_animes.rb
@@ -1,0 +1,5 @@
+class AddStatusToAnimes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :animes, :status, :integer, default: 0, null: false, comment: :ステータス
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_152747) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_05_153516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
   create_table "animes", comment: "アニメ", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_05_153516) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_09_065650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_05_153516) do
     t.string "title", null: false, comment: "タイトル"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false, comment: "ステータス"
     t.index ["title"], name: "index_animes_on_title", unique: true
   end
 


### PR DESCRIPTION
## 内容

- パスワードの再設定機能を削除
- ユーザーと管理者のデフォルトページを分離
- アニメ投稿に失敗した際にフォームにエラーを表示
- アニメ作品は論理削除になるように修正